### PR TITLE
updated shutdown to use a separate thread to kill dump1090

### DIFF
--- a/main/sdr.go
+++ b/main/sdr.go
@@ -89,6 +89,16 @@ func (e *ES) read() {
 				}
 				return
 			default:
+				time.Sleep(1 * time.Second)
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
 				if scanStdout.Scan() {
 					replayLog(scanStdout.Text(), MSGCLASS_DUMP1090)
 				}

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -90,6 +90,7 @@ func (e *ES) read() {
 				return
 			default:
 				time.Sleep(1 * time.Second)
+                        }
 		}
 	}()
 


### PR DESCRIPTION
I've split the closing thread from the reading thread.  This appears to eliminate all dump1090 shutdown hangs.
